### PR TITLE
add sharing attributes to twitter and pinterest

### DIFF
--- a/build/share-buttons.js
+++ b/build/share-buttons.js
@@ -74,16 +74,20 @@ var TwitterShareButton = _react2['default'].createClass({
     className: _react2['default'].PropTypes.string,
     children: _react2['default'].PropTypes.node.isRequired,
     title: _react2['default'].PropTypes.string.isRequired,
-    url: _react2['default'].PropTypes.string.isRequired
+    url: _react2['default'].PropTypes.string.isRequired,
+    via: _react2['default'].PropTypes.string,
+    hashtags: _react2['default'].PropTypes.arrayOf(_react2['default'].PropTypes.string)
   },
 
   render: function render() {
     var _props2 = this.props;
     var url = _props2.url;
     var title = _props2.title;
+    var via = _props2.via;
+    var hashtags = _props2.hashtags;
 
     return _react2['default'].createElement(SocialMediaShareButton, _extends({
-      link: (0, _socialMediaShareLinks.twitter)(url, title)
+      link: (0, _socialMediaShareLinks.twitter)(url, title, via, hashtags)
     }, this.props, {
       className: 'SocialMediaShareButton--twitter' + (' ' + (this.props.className || '')) }));
   }
@@ -140,16 +144,18 @@ var PinterestShareButton = _react2['default'].createClass({
     className: _react2['default'].PropTypes.string,
     children: _react2['default'].PropTypes.node.isRequired,
     media: _react2['default'].PropTypes.string.isRequired,
-    url: _react2['default'].PropTypes.string.isRequired
+    url: _react2['default'].PropTypes.string.isRequired,
+    description: _react2['default'].PropTypes.string
   },
 
   render: function render() {
     var _props4 = this.props;
     var url = _props4.url;
     var media = _props4.media;
+    var description = _props4.description;
 
     return _react2['default'].createElement(SocialMediaShareButton, _extends({
-      link: (0, _socialMediaShareLinks.pinterest)(url, media)
+      link: (0, _socialMediaShareLinks.pinterest)(url, media, description)
     }, this.props, {
       className: 'SocialMediaShareButton--pinterest' + (' ' + (this.props.className || '')) }));
   }

--- a/build/social-media-share-links.js
+++ b/build/social-media-share-links.js
@@ -65,12 +65,13 @@ function linkedin(url, title) {
   return 'https://linkedin.com/shareArticle' + (0, _utils.objectToGetParams)({ url: url, title: title });
 }
 
-function pinterest(url, media) {
+function pinterest(url, media, description) {
   assertProvided(url, 'pinterest');
   assertProvided(media, 'pinterest');
 
   return 'https://pinterest.com/pin/create/button/' + (0, _utils.objectToGetParams)({
     url: url,
-    media: media
+    media: media,
+    description: description
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-share",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Easy social media share buttons and share counts.",
   "main": "./build/react-share.js",
   "scripts": {

--- a/src/share-buttons.jsx
+++ b/src/share-buttons.jsx
@@ -65,18 +65,22 @@ export const TwitterShareButton = React.createClass({
     className: React.PropTypes.string,
     children: React.PropTypes.node.isRequired,
     title: React.PropTypes.string.isRequired,
-    url: React.PropTypes.string.isRequired
+    url: React.PropTypes.string.isRequired,
+    via: React.PropTypes.string,
+    hashtags: React.PropTypes.arrayOf(React.PropTypes.string)
   },
 
   render() {
     const {
       url,
-      title
+      title,
+      via,
+      hashtags
     } = this.props;
 
     return (
       <SocialMediaShareButton
-        link={twitter(url, title)}
+        link={twitter(url, title, via, hashtags)}
         {...this.props}
         className={'SocialMediaShareButton--twitter' +
           ` ${this.props.className || ''}`} />
@@ -135,18 +139,20 @@ export const PinterestShareButton = React.createClass({
     className: React.PropTypes.string,
     children: React.PropTypes.node.isRequired,
     media: React.PropTypes.string.isRequired,
-    url: React.PropTypes.string.isRequired
+    url: React.PropTypes.string.isRequired,
+    description: React.PropTypes.string
   },
 
   render() {
     const {
       url,
-      media
+      media,
+      description
     } = this.props;
 
     return (
       <SocialMediaShareButton
-        link={pinterest(url, media)}
+        link={pinterest(url, media, description)}
         {...this.props}
         className={'SocialMediaShareButton--pinterest' +
           ` ${this.props.className || ''}`} />

--- a/src/social-media-share-links.jsx
+++ b/src/social-media-share-links.jsx
@@ -52,12 +52,13 @@ export function linkedin(url, title) {
   return `https://linkedin.com/shareArticle` + objectToGetParams({url, title});
 }
 
-export function pinterest(url, media) {
+export function pinterest(url, media, description) {
   assertProvided(url, 'pinterest');
   assertProvided(media, 'pinterest');
 
   return `https://pinterest.com/pin/create/button/` + objectToGetParams({
     url,
-    media
+    media,
+    description
   });
 }


### PR DESCRIPTION
Passed along `via` and `hashtags` attributes to twitter sharing; added `description` attribute to pinterest sharing.