### PR TITLE
Call callback on error

### DIFF
--- a/src/share-count-getters.jsx
+++ b/src/share-count-getters.jsx
@@ -12,11 +12,9 @@ export function getFacebookShareCount(shareUrl, callback) {
     `?format=json&query=${fql}`;
 
   jsonp(endpoint, (err, data) => {
-    if (!err) {
-      callback(data.length && data[0].share_count
-        ? data[0].share_count
-        : undefined);
-    }
+    callback(!err && data.length && data[0].share_count
+      ? data[0].share_count
+      : undefined);
   });
 }
 


### PR DESCRIPTION
Make getFacebookShareCount call the callback with undefined if any network error occurs like other share count getters do.

Nice lib btw :)