### PR TITLE
Remove unnecessary style

### DIFF
--- a/src/generateIcon.jsx
+++ b/src/generateIcon.jsx
@@ -30,7 +30,6 @@ export function generateIcon(network) {
       } = this.props;
 
       const baseStyle = {
-        display: 'inline-block',
         width: size,
         height: size,
       };


### PR DESCRIPTION
@nygardk It might be best to be have only the necessary styles (width/height) and leave the rest to the user, what do you think?

Example: I'm using the components within a flexbox and the `display: 'inline-block'` is causing problems. If someone wants to use display: inline-block, then they should add it as a class?