### PR TITLE
make windows width settable

### DIFF
--- a/demos/demo0/Demo.jsx
+++ b/demos/demo0/Demo.jsx
@@ -107,6 +107,7 @@ const Demo = React.createClass({
           <PinterestShareButton
             url={String(window.location)}
             media={`${String(window.location)}/${exampleImage}`}
+            windowWidth={1000}
             className="Demo__some-network__share-button">
             <PinterestIcon size={32} round />
           </PinterestShareButton>

--- a/src/share-buttons.jsx
+++ b/src/share-buttons.jsx
@@ -17,6 +17,8 @@ export default class ShareButton extends Component {
     opts: PropTypes.object,
     url: PropTypes.string.isRequired,
     style: PropTypes.object,
+    windowWidth: PropTypes.number,
+    windowHeight: PropTypes.number,
   };
 
   static defaultProps = {
@@ -28,7 +30,7 @@ export default class ShareButton extends Component {
   onClick = (e) => {
     if (!this.props.disabled) {
       e.preventDefault();
-      windowOpen(this.link());
+      windowOpen(this.link(), undefined, this.props.windowHeight, this.props.windowWidth);
     }
   }
 

--- a/src/share-buttons.jsx
+++ b/src/share-buttons.jsx
@@ -30,7 +30,7 @@ export default class ShareButton extends Component {
   onClick = (e) => {
     if (!this.props.disabled) {
       e.preventDefault();
-      windowOpen(this.link(), undefined, this.props.windowHeight, this.props.windowWidth);
+      windowOpen({ url: this.link(), width: this.props.windowWidth });
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,7 @@ export function objectToGetParams(object) {
     .join('&');
 }
 
-export function windowOpen(url, name, height = 400, width = 550) {
+export function windowOpen({ url, name, height = 400, width = 550 }) {
   const left = (window.outerWidth / 2)
     + (window.screenX || window.screenLeft || 0) - (width / 2);
   const top = (window.outerHeight / 2)


### PR DESCRIPTION
* Make windows width settable to fix pinterest window's width is wide enough.

* Previously, pinterest window is like following which will make user think they may not be able to login. So we should make windows size can be adjustable, so when people use this library, they can decide how big the window it is. 

![image](https://cloud.githubusercontent.com/assets/12647804/17575418/d9a2f7fe-5f1d-11e6-868a-21dbb3eddbbf.png)
