### PR TITLE
add url html property

### DIFF
--- a/src/share-buttons.jsx
+++ b/src/share-buttons.jsx
@@ -69,6 +69,7 @@ export default class ShareButton extends Component {
       <div
         onClick={this.onClick}
         className={classes}
+        url={this.link()}
         style={{
           ...style,
           ...(disabled ? disabledStyle : {}),


### PR DESCRIPTION
Add url property in html, so that when we want to write unit test to detect the functionality of url constructor, we can easily get url as one of the props. 