### PR TITLE
Remove React createClass and PropTypes warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "babel-runtime": "6.6.1",
     "classnames": "2.2.5",
     "jsonp": "0.2.0",
-    "platform": "1.3.2"
+    "platform": "1.3.2",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "react": "0.13.x || 0.14.x || 15.x.x"

--- a/src/generateIcon.jsx
+++ b/src/generateIcon.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import icons from './icons';
 
@@ -9,73 +10,71 @@ export function generateIcon(network) {
 
   const iconConfig = icons[network.toLowerCase()];
 
-  return React.createClass({
-    propTypes: {
-      className: React.PropTypes.string,
-      iconBgStyle: React.PropTypes.object,
-      logoFillColor: React.PropTypes.string,
-      round: React.PropTypes.bool,
-      size: React.PropTypes.number,
-    },
+  const Icon = (props) => {
+    const {
+      className,
+      iconBgStyle,
+      logoFillColor,
+      round,
+      size,
+    } = props;
 
-    getDefaultProps() {
-      return {
-        logoFillColor: 'white',
-        size: 64,
-      };
-    },
+    const baseStyle = {
+      width: size,
+      height: size,
+    };
 
-    render() {
-      const {
-        className,
-        iconBgStyle,
-        logoFillColor,
-        round,
-        size,
-      } = this.props;
+    const classes = `social-icon social-icon--${network} ${className || ''}`;
 
-      const baseStyle = {
-        width: size,
-        height: size,
-      };
+    const finalIconBgStyle = {
+      ...iconBgStyle,
+    };
 
-      const classes = `social-icon social-icon--${network} ${className || ''}`;
+    return (
+      <div style={baseStyle}>
+        <svg
+          viewBox="0 0 64 64"
+          fill={logoFillColor}
+          width={size}
+          height={size}
+          className={classes}>
+          <g>
+            {(!round ? (
+              <rect
+                width="64"
+                height="64"
+                fill={iconConfig.color}
+                style={finalIconBgStyle} />
+            ) : (
+              <circle
+                cx="32"
+                cy="32"
+                r="31"
+                fill={iconConfig.color}
+                style={finalIconBgStyle} />
+            ))}
+          </g>
 
-      const finalIconBgStyle = {
-        ...iconBgStyle,
-      };
+          <g>
+            <path d={iconConfig.icon} />
+          </g>
+        </svg>
+      </div>
+    );
+  };
 
-      return (
-        <div style={baseStyle}>
-          <svg
-            viewBox="0 0 64 64"
-            fill={logoFillColor}
-            width={size}
-            height={size}
-            className={classes}>
-            <g>
-              {(!round ? (
-                <rect
-                  width="64"
-                  height="64"
-                  fill={iconConfig.color}
-                  style={finalIconBgStyle} />
-              ) : (
-                <circle
-                  cx="32"
-                  cy="32"
-                  r="31"
-                  fill={iconConfig.color}
-                  style={finalIconBgStyle} />
-              ))}
-            </g>
+  Icon.propTypes = {
+    className: PropTypes.string,
+    iconBgStyle: PropTypes.object,
+    logoFillColor: PropTypes.string,
+    round: PropTypes.bool,
+    size: PropTypes.number,
+  };
 
-            <g>
-              <path d={iconConfig.icon} />
-            </g>
-          </svg>
-        </div>
-      );
-    },
-  });
+  Icon.defaultProps = {
+    logoFillColor: 'white',
+    size: 64,
+  };
+
+  return Icon;
 }

--- a/src/share-counts.jsx
+++ b/src/share-counts.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-multi-comp */
 import React from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 import {
@@ -11,29 +12,28 @@ import {
   getOKShareCount,
 } from './share-count-getters';
 
-const SocialMediaShareCount = React.createClass({
-  propTypes: {
-    children: React.PropTypes.func,
-    className: React.PropTypes.string,
-    getCount: React.PropTypes.func,
-    url: React.PropTypes.string.isRequired,
-  },
+class SocialMediaShareCount extends React.Component {
+  constructor(props) {
+    super(props);
 
-  getInitialState() {
-    return {
-      count: 0,
-    };
-  },
+    this._isMounted = false;
+    this.state = { count: 0 };
+  }
 
   componentDidMount() {
+    this._isMounted = true;
     this.updateCount(this.props.url);
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.url !== this.props.url) {
       this.updateCount(nextProps.url);
     }
-  },
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
 
   updateCount(url) {
     if (this.props.getCount) {
@@ -42,7 +42,7 @@ const SocialMediaShareCount = React.createClass({
       });
 
       this.props.getCount(url, count => {
-        if (this.isMounted()) {
+        if (this._isMounted) {
           this.setState({
             count,
             isLoading: false,
@@ -50,7 +50,7 @@ const SocialMediaShareCount = React.createClass({
         }
       });
     }
-  },
+  }
 
   render() {
     const {
@@ -68,8 +68,15 @@ const SocialMediaShareCount = React.createClass({
         {!isLoading && children(count || 0)}
       </div>
     );
-  },
-});
+  }
+}
+
+SocialMediaShareCount.propTypes = {
+  children: PropTypes.func,
+  className: PropTypes.string,
+  getCount: PropTypes.func,
+  url: PropTypes.string.isRequired,
+};
 
 SocialMediaShareCount.defaultProps = {
   children: shareCount => shareCount,


### PR DESCRIPTION
Actually removing deprecated behavior for a smoother transition to React v16.