### PR TITLE
Prefix dependency versions with caret (^)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
     "webpack-dev-server": "1.16.3"
   },
   "dependencies": {
-    "babel-runtime": "6.6.1",
-    "classnames": "2.2.5",
-    "jsonp": "0.2.1",
-    "platform": "1.3.4",
+    "babel-runtime": "^6.6.1",
+    "classnames": "^2.2.5",
+    "jsonp": "^0.2.1",
+    "platform": "^1.3.4",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {


### PR DESCRIPTION
This adopts the common practice of using more permissive versioning. This change helps consumers reduce their bundle size by avoiding multiple copies of the same library.