### PR TITLE
Made share buttons accessible to keyboards and assistive tech

### DIFF
--- a/src/share-buttons.jsx
+++ b/src/share-buttons.jsx
@@ -87,6 +87,8 @@ export default class ShareButton extends Component {
 
     return (
       <div
+        role="button"
+        tabIndex="0"
         onClick={this.onClick}
         className={classes}
         style={{


### PR DESCRIPTION
This should address Issue #80. This allows keyboards (and as a result, assistive technology) to access these controls. While a button element would have been preferable, this method doesn't impact styling and achieves the same result.