### PR TITLE
Update What's App share URL to use their new API

### DIFF
--- a/src/social-media-share-links.jsx
+++ b/src/social-media-share-links.jsx
@@ -32,7 +32,7 @@ export function telegram(url, { title }) {
 
 export function whatsapp(url, { title, separator }) {
   assert(url, 'whatsapp.url');
-  return 'whatsapp://send' + objectToGetParams({
+  return 'https://api.whatsapp.com/send' + objectToGetParams({
     text: title + separator + url,
   });
 }


### PR DESCRIPTION
This is documented in their FAQ: https://faq.whatsapp.com/en/26000030/?category=5245251

It opens the desktop/iOS/android app if installed, otherwise it directs the user to the web application.