### PR TITLE
Update deprecated fields in facebook share dialog

### DIFF
--- a/demos/demo0/Demo.jsx
+++ b/demos/demo0/Demo.jsx
@@ -52,8 +52,7 @@ class Demo extends Component {
         <div className="Demo__some-network">
           <FacebookShareButton
             url={shareUrl}
-            title={title}
-            picture={`${String(window.location)}/${exampleImage}`}
+            quote={title}
             className="Demo__some-network__share-button">
             <FacebookIcon
               size={32}

--- a/src/share-buttons.jsx
+++ b/src/share-buttons.jsx
@@ -125,14 +125,10 @@ function createShareButton(network, optsMap = () => ({}), propTypes, defaultProp
 }
 
 export const FacebookShareButton = createShareButton('facebook', props => ({
-  description: props.description,
-  title: props.title,
-  picture: props.picture,
+  quote: props.quote,
   hashtag: props.hashtag,
 }), {
-  description: PropTypes.string,
-  title: PropTypes.string,
-  picture: PropTypes.string,
+  quote: PropTypes.string,
   hashtag: PropTypes.string,
 }, {
   windowWidth: 550,

--- a/src/social-media-share-links.jsx
+++ b/src/social-media-share-links.jsx
@@ -38,6 +38,12 @@ export function whatsapp(url, { title, separator }) {
 }
 
 export function facebook(url, { quote, hashtag }) {
+  /*eslint-disable */
+  if (quote == null) {
+    console.warn('Warning: Description, title and picture fields are no longer supported by react-share! Use quote instead!');
+  }
+  /*eslint-enable */
+
   assert(url, 'facebook.url');
   return 'https://www.facebook.com/sharer/sharer.php' + objectToGetParams({
     u: url,

--- a/src/social-media-share-links.jsx
+++ b/src/social-media-share-links.jsx
@@ -37,14 +37,11 @@ export function whatsapp(url, { title, separator }) {
   });
 }
 
-export function facebook(url, { title, description, picture, hashtag }) {
+export function facebook(url, { quote, hashtag }) {
   assert(url, 'facebook.url');
-
   return 'https://www.facebook.com/sharer/sharer.php' + objectToGetParams({
     u: url,
-    title,
-    description,
-    picture,
+    quote,
     hashtag,
   });
 }


### PR DESCRIPTION
https://developers.facebook.com/docs/apps/changelog
_v2.9
Introduced April 18th, 2017_

> 90-Day Deprecations
> The following fields are deprecated for edges and dialogs that allow attaching links to posts:
- picture
- name
- caption
- thumbnail
- description

From now on, only quotes working in facebook share dialog.