### PR TITLE
Fixed title-prop optionality for WhatsApp shares

### DIFF
--- a/src/social-media-share-links.jsx
+++ b/src/social-media-share-links.jsx
@@ -30,7 +30,7 @@ export function telegram(url, { title }) {
 export function whatsapp(url, { title, separator }) {
   assert(url, 'whatsapp.url');
   return 'https://api.whatsapp.com/send' + objectToGetParams({
-    text: title + separator + url,
+    text: title ? title + separator + url : url,
   });
 }
 


### PR DESCRIPTION
This pull request fixes the bug in `title`-prop of the WhatsApp shares.

`title`-prop is optional. But omitting it will currently corrupt the message with `undefined ` -prefix. This commit fixes the issue.

