### PR TITLE
Reduce bundle sizes by removing dependency to 'platform'. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "babel-runtime": "^6.6.1",
     "classnames": "^2.2.5",
     "jsonp": "^0.2.1",
-    "platform": "^1.3.4",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {

--- a/src/share-count-getters.jsx
+++ b/src/share-count-getters.jsx
@@ -1,7 +1,6 @@
 import jsonp from 'jsonp';
-import platform from 'platform';
 
-import { objectToGetParams } from './utils';
+import { isInternetExplorerBefore, objectToGetParams } from './utils';
 
 
 export function getFacebookShareCount(shareUrl, callback) {
@@ -15,7 +14,7 @@ export function getFacebookShareCount(shareUrl, callback) {
 }
 
 export function getGooglePlusShareCount(shareUrl, callback) {
-  if (platform.name === 'IE' && parseInt(platform.version, 10) < 11) {
+  if (isInternetExplorerBefore(11)) {
     /* eslint-disable no-console */
     console.error('Google plus share count is not supported in <=IE10!');
     /* eslint-enable no-console */

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,22 @@
-/* eslint-disable prefer-template */
-import platform from 'platform';
+/*
+ * This detection method identifies Internet Explorers up until version 11.
+ *
+ * Reference: https://msdn.microsoft.com/en-us/library/ms537503(v=vs.85).aspx
+ */
+export function isInternetExplorerBefore(version) {
+  const iematch = (/MSIE ([0-9]+)/g.exec(window.navigator.userAgent));
 
+  return iematch ? +iematch[1] < version : false;
+}
+
+/* eslint-disable prefer-template */
 export function objectToGetParams(object) {
   return '?' + Object.keys(object)
     .filter(key => !!object[key])
     .map(key => `${key}=${encodeURIComponent(object[key])}`)
     .join('&');
 }
+/* eslint-enable prefer-template */
 
 export function windowOpen(url, { name, height = 400, width = 550 }, onShareWindowClose) {
   const left = (window.outerWidth / 2)
@@ -32,7 +42,7 @@ export function windowOpen(url, { name, height = 400, width = 550 }, onShareWind
 
   const shareDialog = window.open(
     url,
-    platform.name === 'IE' && parseInt(platform.version, 10) < 10 ? '' : name,
+    isInternetExplorerBefore(10) ? '' : name,
     Object.keys(config).map(key => `${key}=${config[key]}`).join(', ')
   );
 


### PR DESCRIPTION
I was checking my bundle sizes when I discovered the following: `react-share` had a dependency to `platform`. This leads to large bundles when `react-share` is used.

The dependency to `platform` brings in about 40kB of JavaScript (perhaps ~11-12kB when gzipped?). It thus effectively doubles the size of `react-share` and brings an unnecessary burden to slow mobile devices & networks.

`platform` was only used to check for IE < 11 and IE < 10. I replaced these checks with a regex. Check https://msdn.microsoft.com/en-us/library/ms537503(v=vs.85).aspx for reference.

I've tested the new detection with these browsers: IE9, IE 10, IE 11 and Chrome. I tried to keep code changes to a minimum.

***

On another topic: would it be ok if I take a look at setting up ES6 module builds for the project as well?