### PR TITLE
EmailShareButton: url is used as the default email body. Fixes #132.

### DIFF
--- a/src/EmailShareButton.js
+++ b/src/EmailShareButton.js
@@ -4,7 +4,7 @@ import objectToGetParams from './utils/objectToGetParams';
 import createShareButton from './utils/createShareButton';
 
 function emailLink(url, { subject, body }) {
-  return 'mailto:' + objectToGetParams({ subject, body: body || subject });
+  return 'mailto:' + objectToGetParams({ subject, body: body || url });
 }
 
 const EmailShareButton = createShareButton('email', emailLink, props => ({


### PR DESCRIPTION
`url` is used as email body unless `body` prop has been specified. This conforms to the README.md documentation. See issue #132 

However the `url` is not used if `body` has been defined. I think this is a safe change and should not break existing usage.