### PR TITLE
Added support for webpack 4 tree shaking with `sideEffects: false` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1 (Apr 8, 2018)
+
+* Added support for `webpack 4` tree shaking with `sideEffects: false`-flag in `package.json`
+
 ## 2.1.0 (Mar 30, 2018)
 
 * Fix: use `https` for TumblrShareCount

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "react-share",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Social media share buttons and share counts for React.",
   "main": "./lib/index.js",
   "module": "./es/index.js",
+  "sideEffects": false,
   "engines": {
     "node": ">=4.0.0",
     "npm": ">=3.0.0"


### PR DESCRIPTION
Adds support for webpack 4 tree shaking with `sideEffects: false` declared in `package.json`.

References:
- #147 
- https://github.com/webpack/webpack/tree/master/examples/side-effects
- https://stackoverflow.com/questions/49160752/what-does-webpack-4-expect-from-a-package-with-sideeffects-false
