### PR TITLE
Add space to fix accessibility error.

### DIFF
--- a/src/utils/createShareButton.jsx
+++ b/src/utils/createShareButton.jsx
@@ -118,7 +118,7 @@ class ShareButton extends PureComponent {
   }
 
   onKeyPress = (e) => {
-    if (e.key === 'Enter' || e.key === 13) {
+    if (e.key === 'Enter' || e.key === 13 || e.key === ' ' || e.key === 32) {
       this.onClick(e);
     }
   }


### PR DESCRIPTION
Space should also work as 'click' for role button.

https://www.w3.org/WAI/GL/wiki/Making_actions_keyboard_accessible_by_using_keyboard_event_handlers_with_WAI-ARIA_controls

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role