### PR TITLE
Error: missing script: run-demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Migrating from v1 to v2? Read [migration notes](./migrate-v1-to-v2.md).
 
 [View demo](http://nygardk.github.io/react-share/)
 
-To run demo: clone repo and run `npm install && npm run run-demo`
+To run demo: clone repo and run `npm install && npm run run-demos`
 and open `http://localhost:8080`.
 
 ## Install


### PR DESCRIPTION
Small fix: 

When I run this: `npm run run-demo` it says `missing script: run-demo` , because it should be `npm run run-demos`