### PR TITLE
Viber shares no longer prepend space and expose the separator as a prop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ import {
 |TumblrShareButton|-|__`title`__: Title of the shared page (string)<br/>__`tags`__: (array)<br/>__`caption`__: Description of the shared page (string)|
 |LivejournalShareButton|-|__`title`__: Title of the shared page (string)<br/>__`description`__: Description of the shared page (string)|
 |MailruShareButton|-|__`title`__: Title of the shared page (string)<br/>__`description`__: Description of the shared page (string)<br/>__`image`__: An absolute link to the image that will be shared (string)|
-|ViberShareButton|-|__`title`__: Title of the shared page (string)<br/>|
+|ViberShareButton|-|__`title`__: Title of the shared page (string)<br/>__`separator`__: Separates title from the url, default: " " (string)|
 |WorkplaceShareButton|-|__`quote`__: A quote to be shared along with the link. (string)<br/>__`hashtag`__: A hashtag specified by the developer to be added to the shared content. People will still have the opportunity to remove this hashtag in the dialog. The hashtag should include the hash symbol. (string)|
 |LineShareButton|-|__`title`__: Title of the shared page (string)|
 |WeiboShareButton|-|__`title`__: Title of the shared page (string)<br/>__`image`__: An absolute link to the image that will be shared (string)|

--- a/demo/Demo.jsx
+++ b/demo/Demo.jsx
@@ -268,7 +268,6 @@ class Demo extends Component {
           <ViberShareButton
             url={shareUrl}
             title={title}
-            body="body"
             className="Demo__some-network__share-button">
             <ViberIcon
               size={32}

--- a/src/ViberShareButton.js
+++ b/src/ViberShareButton.js
@@ -5,18 +5,21 @@ import assert from 'assert';
 import objectToGetParams from './utils/objectToGetParams';
 import createShareButton from './utils/createShareButton';
 
-function viberLink(url, { title }) {
+function viberLink(url, { title, separator }) {
   assert(url, 'viber.url');
   return 'viber://forward' + objectToGetParams({
-    text: `${title || ''} ${url}`,
+    text: title ? title + separator + url : url,
   });
 }
 
 const ViberShareButton = createShareButton('viber', viberLink, props => ({
   title: props.title,
+  separator: props.separator,
 }), {
   title: PropTypes.string,
+  separator: PropTypes.string,
 }, {
+  separator: ' ',
   windowWidth: 660,
   windowHeight: 460,
 });


### PR DESCRIPTION
This PR fixes the following:

- No extra spaces prepended to the url when a title has not been defined
- Demo source code does not try to set up an non-existing `body`-prop
- Exposed the separator as a prop