### PR TITLE
Feat: share button windowPosition prop

### DIFF
--- a/demo/Demo.jsx
+++ b/demo/Demo.jsx
@@ -160,8 +160,6 @@ class Demo extends Component {
           <OKShareButton
             url={shareUrl}
             image={`${String(window.location)}/${exampleImage}`}
-            windowWidth={660}
-            windowHeight={460}
             className="Demo__some-network__share-button">
             <OKIcon
               size={32}

--- a/src/OKShareButton.js
+++ b/src/OKShareButton.js
@@ -25,8 +25,9 @@ const OKShareButton = createShareButton('ok', okLink, props => ({
   description: PropTypes.string,
   image: PropTypes.string,
 }, {
-  windowWidth: 660,
-  windowHeight: 460,
+  windowWidth: 588,
+  windowHeight: 480,
+  windowPosition: 'screenCenter',
 });
 
 export default OKShareButton;

--- a/src/WeiboShareButton.js
+++ b/src/WeiboShareButton.js
@@ -23,8 +23,9 @@ const WeiboShareButton = createShareButton('weibo', weiboLink, props => ({
   title: PropTypes.string,
   image: PropTypes.string,
 }, {
-  windowWidth: 550,
-  windowHeight: 400,
+  windowWidth: 650,
+  windowHeight: 350,
+  windowPosition: 'screenCenter',
 });
 
 export default WeiboShareButton;


### PR DESCRIPTION
- Adds `windowPosition` prop for share buttons
- Refactors share window position calculation logic
- Sets `windowPosition="screenCenter"` as default for `WeiboShareButton` to prevent the window from jumping after opening

(as discussed at https://github.com/nygardk/react-share/pull/210#pullrequestreview-199927644)