### PR TITLE
Fix: remove assert for image on weiboLink

### DIFF
--- a/src/WeiboShareButton.js
+++ b/src/WeiboShareButton.js
@@ -7,7 +7,6 @@ import createShareButton from './utils/createShareButton';
 
 function weiboLink(url, { title, image }) {
   assert(url, 'weibo.url');
-  assert(image, 'weibo.image');
 
   return 'http://service.weibo.com/share/share.php?' + objectToGetParams({
     url,


### PR DESCRIPTION
Removes assertion for image parameter on weiboLink. (Should not be required, right?)