### PR TITLE
fix weibo share does not contain url

### DIFF
--- a/src/WeiboShareButton.js
+++ b/src/WeiboShareButton.js
@@ -9,7 +9,7 @@ function weiboLink(url, { title, image }) {
   assert(url, 'weibo.url');
   assert(image, 'weibo.image');
 
-  return 'http://service.weibo.com/share/share.php?' + objectToGetParams({
+  return 'http://service.weibo.com/share/share.php' + objectToGetParams({
     url,
     title,
     pic: image,


### PR DESCRIPTION
before: 

<img width="350" alt="wx20190305-111601 2x" src="https://user-images.githubusercontent.com/3297859/53778726-b2ae5a00-3f38-11e9-8bca-5c13fa31ea8c.png">

after: 

<img width="350" alt="wx20190305-111848 2x" src="https://user-images.githubusercontent.com/3297859/53778727-b2ae5a00-3f38-11e9-9286-ad93482218ce.png">
