### PR TITLE
Fixing Facebook Graph v3.3 API update issues.

### DIFF
--- a/src/FacebookShareCount.js
+++ b/src/FacebookShareCount.js
@@ -2,12 +2,12 @@ import jsonp from 'jsonp';
 
 import shareCountFactory from './utils/shareCountFactory';
 
-function getFacebookShareCount(shareUrl, callback) {
-  const endpoint = `https://graph.facebook.com/?id=${shareUrl}`;
+function getFacebookShareCount(shareUrl, callback, accessToken) {
+  const endpoint = `https://graph.facebook.com/?id=${shareUrl}&fields=engagement&access_token=${accessToken}`;
 
   jsonp(endpoint, (err, data) => {
-    callback(!err && data && data.share && data.share.share_count
-      ? data.share.share_count
+    callback(!err && data && data.engagement && data.engagement.share_count
+      ? data.engagement.share_count
       : undefined);
   });
 }

--- a/src/utils/shareCountFactory.jsx
+++ b/src/utils/shareCountFactory.jsx
@@ -38,7 +38,8 @@ class SocialMediaShareCount extends Component {
             isLoading: false,
           });
         }
-      });
+      }, 
+      (this.props.accessToken ? this.props.accessToken : null));
     }
   }
 
@@ -66,6 +67,7 @@ SocialMediaShareCount.propTypes = {
   className: PropTypes.string,
   getCount: PropTypes.func,
   url: PropTypes.string.isRequired,
+  accessToken: PropTypes.string
 };
 
 SocialMediaShareCount.defaultProps = {


### PR DESCRIPTION
Addressing [Issue #228](https://github.com/nygardk/react-share/issues/228)

This is a workaround for the issues created by Facebook's Graph API Update (Currently v3.3).

Facebook Graph API requires an access token to retrieve share statistics. The return object structure has changed as well. ( {engagement} vs. {share} ).

To get your access token, follow the steps below.

**1.** You would need to create an Facebook app for your website. [Facebook Developers](https://developers.facebook.com/).

**2.** Go to "My Apps" -> Click "Tools" -> Click "Graph API Explorer"

**3.** Click "Get Token" and Choose the option, "Get App Token" and copy/paste the resulting token.

I added an additional optional property to the ShareCount component. You can pass your access token as a property for the FacebookShareCount component. If this property isn't available, default behavior will apply. (i.e., Count = 0)

