### PR TITLE
Support refs

### DIFF
--- a/src/utils/createShareButton.jsx
+++ b/src/utils/createShareButton.jsx
@@ -199,12 +199,13 @@ class ShareButton extends PureComponent {
 }
 
 function createShareButton(network, link, optsMap = () => ({}), propTypes, defaultProps = {}) {
-  const CreatedButton = props => (
+  const CreatedButton = React.forwardRef((props, ref) => (
     <ShareButton {...props}
+      ref={ref}
       network={network}
       networkLink={link}
       opts={optsMap(props)} />
-  );
+  ));
 
   CreatedButton.propTypes = propTypes;
   CreatedButton.defaultProps = defaultProps;


### PR DESCRIPTION
This branch uses `React.forwardRef` to add `ref` support to the share buttons. I implemented this changed based on the instructions listed [here](https://reactjs.org/docs/forwarding-refs.html).

I was originally inspired to make this change as a result of a new caveat in `@material-ui/core` v4 (https://material-ui.com/guides/composition/#caveat-with-refs) where components passed to the `component` prop of certain MUI components, like a `Button` must support refs. The MUI `component` prop is useful if I wanted to make a share button that follows the style of the other buttons in my app. 

For example:

```js
import {TwitterShareButton} from 'react-share';
import {Button} from '@material-ui/core';

// doesn't work anymore since TwitterShareButton doesn't support refs :(
<Button
  component={TwitterShareButton}
  url="https://example.com"
/>
```