### PR TITLE
Replace unsafe lifecycle method `componentWillReceiveProps`

### DIFF
--- a/src/utils/shareCountFactory.jsx
+++ b/src/utils/shareCountFactory.jsx
@@ -15,9 +15,9 @@ class SocialMediaShareCount extends Component {
     this.updateCount(this.props.url);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.url !== this.props.url) {
-      this.updateCount(nextProps.url);
+  componentDidUpdate(prevProps) {
+    if (prevProps.url !== this.props.url) {
+      this.updateCount(this.props.url);
     }
   }
 


### PR DESCRIPTION
To get rid of the warnings in the console.

See 
* https://reactjs.org/blog/2018/03/29/react-v-16-3.html#component-lifecycle-changes
* https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#renaming-unsafe-lifecycle-methods