### PR TITLE
Update VK share button properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ import {
 |TelegramShareButton|-|__`title`__: Title of the shared page (string)<br/>|
 |WhatsappShareButton|-|__`title`__: Title of the shared page (string)<br/>__`separator`__: Separates title from the url, default: " " (string)|
 |PinterestShareButton|__`media`__: An absolute link to the image that will be pinned (string)|__`description`__: Description for the shared media.|
-|VKShareButton|-|__`title`__: Title of the shared page (string)<br/>__`description`__: Description of the shared page (string)<br/>__`image`__: An absolute link to the image that will be shared (string)|
+|VKShareButton|-|__`title`__: Title of the shared page (string)<br/>__`image`__: An absolute link to the image that will be shared (string)<br/>__`noParse`__: If true is passed, VK will not retrieve URL information (bool)<br/>__`noVkLinks`__: If true is passed, there will be no links to the user's profile in the open window. Only for mobile devices (bool)|
 |OKShareButton|-|__`title`__: Title of the shared page (string)<br/>__`description`__: Description of the shared page (string)<br/>__`image`__: An absolute link to the image that will be shared (string)|
 |RedditShareButton|-|__`title`__: Title of the shared page (string)|
 |TumblrShareButton|-|__`title`__: Title of the shared page (string)<br/>__`tags`__: (array)<br/>__`caption`__: Description of the shared page (string)|

--- a/src/VKShareButton.js
+++ b/src/VKShareButton.js
@@ -5,25 +5,28 @@ import assert from 'assert';
 import objectToGetParams from './utils/objectToGetParams';
 import createShareButton from './utils/createShareButton';
 
-function vkLink(url, { title, description, image }) {
+function vkLink(url, { title, image, noParse, noVkLinks }) {
   assert(url, 'vk.url');
 
   return 'https://vk.com/share.php' + objectToGetParams({
     url,
     title,
-    description,
     image,
+    noparse: noParse ? 1 : 0,
+    no_vk_links: noVkLinks ? 1 : 0,
   });
 }
 
 const VKShareButton = createShareButton('vk', vkLink, props => ({
   title: props.title,
-  description: props.description,
   image: props.image,
+  noParse: props.noParse,
+  noVkLinks: props.noVkLinks,
 }), {
   title: PropTypes.string,
-  description: PropTypes.string,
   image: PropTypes.string,
+  noParse: PropTypes.bool,
+  noVkLinks: PropTypes.bool,
 }, {
   windowWidth: 660,
   windowHeight: 460,


### PR DESCRIPTION
Changes:
* removed `description` property, no longer supported
* added `noParse` property, if true, VK will not retrieve URL information on share page
* added `noVkLinks` property, if true, there will be no links to the user's profile in the open window (only for mobile devices)

Docs there: https://vk.com/dev/widget_share, unfortunately only in Russian.