### PR TITLE
Allow beforeOnClick to manipulate the shared link

### DIFF
--- a/src/utils/createShareButton.jsx
+++ b/src/utils/createShareButton.jsx
@@ -108,9 +108,7 @@ class ShareButton extends PureComponent {
 
     e.preventDefault();
 
-    const link = this.link();
-
-    const clickHandler = openWindow ? () => this.openWindow(link) : () => onClick(link);
+    const clickHandler = openWindow ? () => this.openWindow(this.link()) : () => onClick(this.link());
 
     if (beforeOnClick) {
       const returnVal = beforeOnClick();


### PR DESCRIPTION
These changes allow the function called in _beforeOnClick_ to manipulate the link of the _ShareButton_. Fixes #216