### PR TITLE
Remove `getCount` prop from DOM node

### DIFF
--- a/src/hocs/createShareCount.tsx
+++ b/src/hocs/createShareCount.tsx
@@ -55,7 +55,7 @@ class SocialMediaShareCount extends Component<SocialMediaShareCountProps, StateT
   render() {
     const { count, isLoading } = this.state;
 
-    const { children = defaultChildren, className, ...rest } = this.props;
+    const { children = defaultChildren, className, getCount: _, ...rest } = this.props;
 
     return (
       <span className={cx('react-share__ShareCount', className)} {...rest}>


### PR DESCRIPTION
Fixes #279

Removes the `getCount` prop from the `rest` properties, which are forwarded to the native DOM element.