### PR TITLE
Call correct callback with multiple Odnoklassniki share button

### DIFF
--- a/src/OKShareCount.ts
+++ b/src/OKShareCount.ts
@@ -34,7 +34,7 @@ function getOKShareCount(shareUrl: string, callback: (shareCount?: number) => vo
 
   window.ODKL = {
     updateCount(a, b) {
-      window.OK.callbacks[index](b);
+      window.OK.callbacks[parseInt(a)](b);
     },
   };
   window.OK.callbacks.push(callback);
@@ -43,7 +43,7 @@ function getOKShareCount(shareUrl: string, callback: (shareCount?: number) => vo
     url +
       objectToGetParams({
         'st.cmd': 'extLike',
-        uid: 'odklcnt0',
+        uid: index,
         ref: shareUrl,
       }),
   );


### PR DESCRIPTION
Hi! This PR resolves issue with multiple Odnoklassniki(ok.ru) share count components on same page.

Issue: It send static uid to OK API and doesn't read uid from response, so after response it calls always last callback in array `window.OK.callbacks` and share count updated only on last element on page