### PR TITLE
Handle no hashtag for Twitter

### DIFF
--- a/src/TwitterShareButton.ts
+++ b/src/TwitterShareButton.ts
@@ -16,7 +16,7 @@ function twitterLink(
       url,
       text: title,
       via,
-      hashtags: hashtags.join(','),
+      hashtags: hashtags.length > 0 ? hashtags.join(',') : undefined,
     })
   );
 }


### PR DESCRIPTION
If you pass Twitter an empty string (which is what happens when you call Array.join on an empty array), Twitter adds an empty hashtag to the post when sharing with the native app on iOS. I haven't checked Android. Web seems fine. See issue #284.