### PR TITLE
Secure record in window.VK

### DIFF
--- a/src/VKShareCount.ts
+++ b/src/VKShareCount.ts
@@ -6,23 +6,20 @@ import createShareCount from './hocs/createShareCount';
 declare global {
   interface Window {
     VK: {
-      Share: {
+      Share?: {
         count: (index: number, count: number) => void;
       };
-      callbacks: ((count?: number) => void)[];
+      callbacks?: ((count?: number) => void)[];
     };
   }
 }
 
 function getVKShareCount(shareUrl: string, callback: (shareCount?: number) => void) {
-  if (!window.VK) {
-    window.VK = {
-      Share: {
-        count: (index, count) => window.VK.callbacks[index](count),
-      },
-      callbacks: [],
-    };
-  }
+  if (!window.VK) window.VK = {};
+  window.VK.Share = {
+    count: (index, count) => window.VK.callbacks![index](count),
+  };
+  window.VK.callbacks = [];
 
   const url = 'https://vk.com/share.php';
   const index = window.VK.callbacks.length;


### PR DESCRIPTION
Global object **window.VK** can be used by official api https://vk.com/js/api/openapi.js what can cause conflicts and errors like:

> Uncaught TypeError: Cannot read property 'length' of undefined
>     at Object.getCount (VKShareCount.js:14)