### PR TITLE
Add default viber separator

### DIFF
--- a/src/ViberShareButton.ts
+++ b/src/ViberShareButton.ts
@@ -18,10 +18,9 @@ const ViberShareButton = createShareButton<{ title?: string; separator?: string 
   viberLink,
   props => ({
     title: props.title,
-    separator: props.separator,
+    separator: props.separator || ' ',
   }),
   {
-    separator: ' ',
     windowWidth: 660,
     windowHeight: 460,
   },


### PR DESCRIPTION
In the current implementation, if the separator is not provided on the component it translates to `undefined`

![image](https://user-images.githubusercontent.com/1364213/83573925-aa264400-a52c-11ea-939a-f14c59b0a88e.png)

viber://forward?text=Testundefinedwww.google.com