### PR TITLE
Update telegram link

### DIFF
--- a/src/TelegramShareButton.ts
+++ b/src/TelegramShareButton.ts
@@ -6,7 +6,7 @@ function telegramLink(url: string, { title }: { title?: string }) {
   assert(url, 'telegram.url');
 
   return (
-    'https://telegram.me/share/' +
+    'https://telegram.me/share/url' +
     objectToGetParams({
       url,
       text: title,


### PR DESCRIPTION
Telegram is using `https://t.me/share/url?url={url}&text={text}` format for [custom share button](https://core.telegram.org/widgets/share#custom-buttons) now. 
So without `/url` we have problems with redirect on IOS. 