### PR TITLE
Replace classnames with clsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   "license": "MIT",
   "devDependencies": {
     "@types/assert": "^1.5.2",
-    "@types/classnames": "^2.2.10",
     "@types/jsonp": "^0.2.0",
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
@@ -87,7 +86,7 @@
     "webpack-dev-server": "3.11.0"
   },
   "dependencies": {
-    "classnames": "^2.2.5",
+    "clsx": "^1.1.1",
     "jsonp": "^0.2.1"
   },
   "peerDependencies": {

--- a/src/ShareButton.tsx
+++ b/src/ShareButton.tsx
@@ -1,5 +1,5 @@
 import React, { Component, Ref } from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 
 type NetworkLink<LinkOptions> = (url: string, options: LinkOptions) => string;
 
@@ -190,7 +190,7 @@ export default class ShareButton<LinkOptions> extends Component<Props<LinkOption
       ...rest
     } = this.props;
 
-    const newClassName = cx(
+    const newClassName = clsx(
       'react-share__ShareButton',
       {
         'react-share__ShareButton--disabled': !!disabled,

--- a/src/hocs/createShareCount.tsx
+++ b/src/hocs/createShareCount.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 
 const defaultChildren = (shareCount: number) => shareCount;
 
@@ -58,7 +58,7 @@ class SocialMediaShareCount extends Component<SocialMediaShareCountProps, StateT
     const { children = defaultChildren, className, getCount: _, ...rest } = this.props;
 
     return (
-      <span className={cx('react-share__ShareCount', className)} {...rest}>
+      <span className={clsx('react-share__ShareCount', className)} {...rest}>
         {!isLoading && count !== undefined && children(count)}
       </span>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,11 +92,6 @@
   resolved "https://registry.yarnpkg.com/@types/assert/-/assert-1.5.2.tgz#dbc440f6bd7a83b03c37c65e81076d07cf8becdc"
   integrity sha512-DLsoZH9z5DLDi6qMbXKqeqlQLK1h3rfR9dK+KX8UJSGHJylvIZPOCQEKr/d/FClPoZE/eHOa3+e270eUJCUTog==
 
-"@types/classnames@^2.2.10":
-  version "2.2.10"
-  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.10.tgz#cc658ca319b6355399efc1f5b9e818f1a24bf999"
-  integrity sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ==
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1095,11 +1090,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
-
 clean-css@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
@@ -1120,6 +1110,11 @@ cliui@^5.0.0:
     string-width "^3.1.0"
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
+
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
 
 collection-visit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
clsx is fully compatible with classnames API, is quickly gaining traction and is about 1/3rd smaller than classnames.