### PR TITLE
Fix behavior when hatena share count is 0.

### DIFF
--- a/src/HatenaShareCount.ts
+++ b/src/HatenaShareCount.ts
@@ -12,7 +12,7 @@ function getHatenaShareCount(shareUrl: string, callback: (shareCount?: number) =
         url: shareUrl,
       }),
     (err, data) => {
-      callback(data ? data : undefined);
+      callback(data ?? undefined);
     },
   );
 }


### PR DESCRIPTION
Hello.
Thank you for creating a great package!
I found a bug in the hatena share count and send a pull requset for a fix.
When share count is 0, It will behave like this.

```ts
// data is 0, will be interpreted as false and set undefined.
callback(data ? data : undefined)
```

So, if hatena share count is 0, it will just return an empty span element.

![スクリーンショット 2022-01-17 2 31 02](https://user-images.githubusercontent.com/19406706/149671008-a2906442-3b9b-4d17-a3af-ee0df2131bdb.png)

To improve this, I have changed to use nullish coalescing operator.
This way, 0 will be displayed correctly when share count is 0.

I apologize if this is hard to read as it may be in poor English.
I'd love it if you could incorporate this request!