### PR TITLE
Use just api. in WhatsappShareButton.ts

### DIFF
--- a/src/WhatsappShareButton.ts
+++ b/src/WhatsappShareButton.ts
@@ -1,6 +1,6 @@
 import assert from './utils/assert';
 import objectToGetParams from './utils/objectToGetParams';
-import createShareButton from './hocs/createShareButton
+import createShareButton from './hocs/createShareButton';
 
 function whatsappLink(url: string, { title, separator }: { title?: string; separator?: string }) {
   assert(url, 'whatsapp.url');

--- a/src/WhatsappShareButton.ts
+++ b/src/WhatsappShareButton.ts
@@ -1,17 +1,11 @@
 import assert from './utils/assert';
 import objectToGetParams from './utils/objectToGetParams';
-import createShareButton from './hocs/createShareButton';
-
-function isMobileOrTablet() {
-  return /(android|iphone|ipad|mobile)/i.test(navigator.userAgent);
-}
+import createShareButton from './hocs/createShareButton
 
 function whatsappLink(url: string, { title, separator }: { title?: string; separator?: string }) {
   assert(url, 'whatsapp.url');
   return (
-    'https://' +
-    (isMobileOrTablet() ? 'api' : 'web') +
-    '.whatsapp.com/send' +
+    'https://api.whatsapp.com/send' +
     objectToGetParams({
       text: title ? title + separator + url : url,
     })


### PR DESCRIPTION
Use just ```api.whatsapp.com``` instead of choosing between ```api.whatsapp.com``` and ```web.whatsapp.com```, because api now handles all scenarios (Web, Mobile and Desktop)