### PR TITLE
fix: prevent title from being passed to the button element

### DIFF
--- a/.changeset/late-horses-enjoy.md
+++ b/.changeset/late-horses-enjoy.md
@@ -1,0 +1,5 @@
+---
+"react-share": patch
+---
+
+The `title` prop is no longer passed to the `button` element, which may have caused e.g. warnings in the console before. Note that to set the native `title` attribute for the share buttons, you may use the `htmlTitle` prop.

--- a/src/ShareButton.tsx
+++ b/src/ShareButton.tsx
@@ -122,6 +122,8 @@ export default function ShareButton<LinkOptions extends Record<string, unknown>>
   opts,
   resetButtonStyle = true,
   style,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  title, // deconstructed from ...rest to prevent passing it to the button element
   url,
   windowHeight = 400,
   windowPosition = 'windowCenter',


### PR DESCRIPTION
Fixes #530 