### PR TITLE
Reddit Share button Update the submit URL

### DIFF
--- a/.changeset/dirty-ladybugs-study.md
+++ b/.changeset/dirty-ladybugs-study.md
@@ -1,0 +1,5 @@
+---
+"react-share": patch
+---
+
+This patch fixes an issue with the Reddit sharing functionality, where the shared link was not automatically populated in Reddit’s share preview. By appending /web before /submit in the Reddit share URL, the link now populates correctly, improving the user experience for Reddit sharing.

--- a/src/RedditShareButton.ts
+++ b/src/RedditShareButton.ts
@@ -6,7 +6,7 @@ function redditLink(url: string, { title }: { title?: string }) {
   assert(url, 'reddit.url');
 
   return (
-    'https://www.reddit.com/submit' +
+    'https://www.reddit.com/web/submit' +
     objectToGetParams({
       url,
       title,


### PR DESCRIPTION
fix(Reddit share): Automatically populate link in Reddit share URL

Issue: [#546](https://github.com/nygardk/react-share/issues/546)

Problem:
- The link was not automatically populated when sharing via Reddit.

Solution:
- Added `/web` as a route prefix before `/submit` in the Reddit share URL to ensure the link populates correctly.

Testing:
- Verified that the link is now correctly populated in Reddit share previews.
