### PR TITLE
fix: remove unused networkname props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-share",
-  "version": "5.1.2",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-share",
-      "version": "5.1.2",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",

--- a/src/ShareButton.tsx
+++ b/src/ShareButton.tsx
@@ -86,7 +86,6 @@ export interface Props<LinkOptions>
    * Passes as the native `title` atribute for the `button` element.
    */
   htmlTitle?: HTMLButtonElement['title'];
-  networkName: string;
   networkLink: NetworkLink<LinkOptions>;
   onClick?: (event: React.MouseEvent<HTMLButtonElement>, link: string) => void;
   /**
@@ -115,7 +114,6 @@ export default function ShareButton<LinkOptions extends Record<string, unknown>>
   forwardedRef,
   htmlTitle,
   networkLink,
-  // networkName, // TODO
   onClick,
   onShareWindowClose,
   openShareDialogOnClick = true,

--- a/src/hocs/createShareButton.tsx
+++ b/src/hocs/createShareButton.tsx
@@ -38,7 +38,6 @@ function createShareButton<
         {...defaultProps}
         {...passedProps}
         forwardedRef={ref}
-        networkName={networkName}
         networkLink={link}
         opts={opts}
       />


### PR DESCRIPTION
**Version to fix:** v5.2.0

**Description of the changes:** I removed `networkname` Props of `CreateShareButton` component since the props was not used anymore and rendered in the DOM. 

**Screenshot of the DOM before my changes:**
![Screenshot from 2025-02-03 10-46-54](https://github.com/user-attachments/assets/7674dfe5-51a6-44a6-abe2-93a49c174efc)

**Screenshot of the DOM after my changes:**
![Screenshot from 2025-02-03 10-46-29](https://github.com/user-attachments/assets/c5dfa5e9-9467-4b81-ba8e-ebeac75dcd40)

Screenshots were taken from React Share Demo