### PR TITLE
feat(tumblr): add support for content field

### DIFF
--- a/.changeset/spicy-ghosts-grin.md
+++ b/.changeset/spicy-ghosts-grin.md
@@ -1,0 +1,5 @@
+---
+"react-share": minor
+---
+
+Add content field to TumblrShareButton

--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Optional props:
 - `tags` (`string[]`): Tags to attach to the post.
 - `caption` (`string`): Description shown with the shared page.
 - `posttype` (`string`, default `"link"`): Tumblr post type.
+- `content` (`string`): The content for some post types. See [Tumblr's documentation](https://help.tumblr.com/knowledge-base/share-button-documentation/) for details.
 
 ```jsx
 import { TumblrShareButton, TumblrIcon } from "react-share";

--- a/src/TumblrShareButton.tsx
+++ b/src/TumblrShareButton.tsx
@@ -10,7 +10,14 @@ function tumblrLink(
     caption,
     tags,
     posttype,
-  }: { title?: string; caption?: string; tags?: string; posttype?: 'link' | string },
+    content,
+  }: {
+    title?: string;
+    caption?: string;
+    tags?: string;
+    posttype?: 'link' | string;
+    content?: string;
+  },
 ) {
   assert(url, 'tumblr.url');
 
@@ -22,6 +29,7 @@ function tumblrLink(
       caption,
       tags,
       posttype,
+      content,
     })
   );
 }
@@ -29,14 +37,15 @@ function tumblrLink(
 type Options = {
   title?: string;
   caption?: string;
-  posttype?: 'link' | string;
+  posttype?: 'link' | 'text' | 'quote' | 'photo' | 'chat' | 'video' | string;
+  content?: string;
 };
 
 type TumblrShareButtonProps = Omit<ShareButtonProps<Options & { tags: string }>, 'title'> &
   Options & { tags?: string[] };
 
 const TumblrShareButton = forwardRef<HTMLButtonElement, TumblrShareButtonProps>(
-  ({ caption, posttype, tags, title, ...props }, ref) => (
+  ({ caption, posttype, tags, title, content, ...props }, ref) => (
     <ShareButton
       {...props}
       forwardedRef={ref}
@@ -47,6 +56,7 @@ const TumblrShareButton = forwardRef<HTMLButtonElement, TumblrShareButtonProps>(
         tags: (tags || []).join(','),
         caption,
         posttype: posttype || 'link',
+        content,
       }}
       windowHeight={460}
       windowWidth={660}


### PR DESCRIPTION
This PR adds support for the Tumblr `content` field.

While for the default `link` type, the canonicalUrl is used, for other posttype values the `content` field is where actual data is entered.

I also added the rest of the `posttype` values from the Tumblr docs to the types (https://help.tumblr.com/knowledge-base/share-button-documentation/)

This was tested by manually editing the demo to type `quote`,  and setting the value `the quote` as the content field, showing the following: 
![image](https://github.com/user-attachments/assets/5acc2644-900f-483b-bcfc-1fef006994fa)
