### PR TITLE
remove "web" from reddit share url

### DIFF
--- a/.changeset/honest-swans-swim.md
+++ b/.changeset/honest-swans-swim.md
@@ -1,0 +1,13 @@
+---
+"react-share": patch
+---
+
+Remove "web" element from path for RedditShareButton
+
+Current issue:
+- The current share url leads to a "Page not found" error, making sharing to Reddit impossible
+- Example: https://www.reddit.com/web/submit?url=http%3A%2F%2Flocalhost%3A3000%2Fblog%2Fblog-post&title=Blog+post&type=LINK
+
+Fix:
+- Changed the path so it works correctly
+- Example: https://www.reddit.com/submit?url=http%3A%2F%2Flocalhost%3A3000%2Fblog%2Fblog-post&title=Blog+post&type=LINK

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-share",
-  "version": "5.1.2",
+  "version": "5.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-share",
-      "version": "5.1.2",
+      "version": "5.2.2",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-share",
-  "version": "5.2.2",
+  "version": "5.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-share",
-      "version": "5.2.2",
+      "version": "5.1.2",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.2",

--- a/src/RedditShareButton.ts
+++ b/src/RedditShareButton.ts
@@ -6,7 +6,7 @@ function redditLink(url: string, { title }: { title?: string }) {
   assert(url, 'reddit.url');
 
   return (
-    'https://www.reddit.com/web/submit' +
+    'https://www.reddit.com/submit' +
     objectToGetParams({
       url,
       title,

--- a/src/RedditShareButton.ts
+++ b/src/RedditShareButton.ts
@@ -6,7 +6,7 @@ function redditLink(url: string, { title }: { title?: string }) {
   assert(url, 'reddit.url');
 
   return (
-    'https://www.reddit.com/submit' +
+    'https://www.reddit.com/web/submit' +
     objectToGetParams({
       url,
       title,


### PR DESCRIPTION
Remove "web" element from path for RedditShareButton

**Current issue:**
- The current share url leads to a "Page not found" error, making sharing to Reddit impossible
- Example: https://www.reddit.com/web/submit?url=http%3A%2F%2Flocalhost%3A3000%2Fblog%2Fblog-post&title=Blog+post&type=LINK

**Fix:**
- Changed the path so it works correctly
- Example: https://www.reddit.com/submit?url=http%3A%2F%2Flocalhost%3A3000%2Fblog%2Fblog-post&title=Blog+post&type=LINK